### PR TITLE
std::back_inserter defined in <iterator> header

### DIFF
--- a/include/read_rgba_from_png.h
+++ b/include/read_rgba_from_png.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <iterator>
 inline bool read_rgba_from_png(
   const std::string & filename,
   std::vector<unsigned char> & rgba,


### PR DESCRIPTION
When compiling using the visual studio community 2019 64 bit compiler, I got the errors:
error C2039: 'back_inserter': is not a member of 'std' 
message : see declaration of 'std'
error C3861: 'back_inserter': identifier not found 

I found that std::back_inserter is defined in the \<iterator\> header, which was not included. 
https://www.cplusplus.com/reference/iterator/back_inserter/

The solution compiles fine when I add this.